### PR TITLE
Enable recursive trimming

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -192,13 +192,13 @@ Below is an index of every sub‑command with a one‑line summary.  Click the �
 
 | Flag                    | Required | Example                                  |
 | ----------------------- | -------- | ---------------------------------------- |
-| `-i / --input_dir DIR`  | ✓        | `raw_traces/`                            |
+| `-i / --input_dir DIR`  | ✓        | `raw_traces/` (recurses)                            |
 | `-o / --output_dir DIR` | ✓        | `fastq/`                                 |
 | `--overwrite`           |          | Re‑convert even if FASTQs already exist. |
 
 | Flag                       | Required | Example            |
 | -------------------------- | -------- | ------------------ |
-| `-i / --input_dir DIR`     | ✓        | `qc/`              |
+| `-i / --input_dir DIR`     | ✓        | `qc/` (recurses)   |
 | `-o / --output_fasta PATH` | ✓        | `qc/trimmed.fasta` |
 
 | Flag                 | Required | Example            |

--- a/src/microseq_tests/microseq.py
+++ b/src/microseq_tests/microseq.py
@@ -49,8 +49,10 @@ def main() -> None:
     # ── AB1 → FASTQ -------------------------------------------------------
     p_ab1 = sp.add_parser("ab1-to-fastq",
                           help="Convert ABI chromatograms to FASTQ")
-    p_ab1.add_argument("-i", "--input_dir",  required=True, metavar="DIR",
-                       help="Folder containing *.ab1 files")
+    p_ab1.add_argument(
+        "-i", "--input_dir", required=True, metavar="DIR",
+        help="Folder containing *.ab1 files; sub-directories are scanned recursively",
+    )
     p_ab1.add_argument("-o", "--output_dir", required=True, metavar="DIR",
                        help="Folder to write *.fastq files")
     p_ab1.add_argument("--overwrite", action="store_true",
@@ -59,8 +61,10 @@ def main() -> None:
     # ── FASTQ → FASTA -----------------------------------------------------
     p_fq = sp.add_parser("fastq-to-fasta",
                          help="Merge all FASTQ in a folder into one FASTA")
-    p_fq.add_argument("-i", "--input_dir",    required=True, metavar="DIR",
-                      help="Folder with *.fastq / *.fq")
+    p_fq.add_argument(
+        "-i", "--input_dir", required=True, metavar="DIR",
+        help="Folder with *.fastq / *.fq; scanned recursively",
+    )
     p_fq.add_argument("-o", "--output_fasta", required=True, metavar="FASTA",
                       help="Output FASTA file path") 
     

--- a/src/microseq_tests/trimming/ab1_to_fastq.py
+++ b/src/microseq_tests/trimming/ab1_to_fastq.py
@@ -25,12 +25,15 @@ def ab1_folder_to_fastq(
         overwrite: bool = False,
         ) -> List[Path]:
     """
-    Convert every *.ab1 input_dir to FASTQ and write them to output_dir. 
+    Convert every ``*.ab1`` file in ``input_dir`` to FASTQ and write them to
+    ``output_dir``.  ``input_dir`` is scanned recursively, so any
+    sub‑directories containing traces are also processed.
 
     Paramteres 
     
-    input_dir : str | Path 
-        Folder containing AB1 chromatograms. 
+    input_dir : str | Path
+        Folder containing ``.ab1`` chromatograms.  Sub‑directories are
+        searched recursively.
     output_dir : str | Path 
         Where FASTQ files will be written (created if missing). 
     overwrite : bool, default False 
@@ -47,7 +50,7 @@ def ab1_folder_to_fastq(
 
     out_files: list[Path] = [] 
 
-    for ab1 in sorted(input_dir.glob("*ab1")):
+    for ab1 in sorted(input_dir.rglob("*.ab1")):
         out_fq = output_dir / f"{ab1.stem}.fastq"
         if out_fq.exists() and not overwrite:
             out_files.append(out_fq)

--- a/src/microseq_tests/trimming/fastq_to_fasta.py
+++ b/src/microseq_tests/trimming/fastq_to_fasta.py
@@ -6,11 +6,15 @@ from Bio import SeqIO
 
 def fastq_folder_to_fasta(input_dir: str | Path, 
                           out_fa: str | Path) -> Path:
-    """ Merges *.fastq in input_dir into one FASTA file out_fa (output_fasta) """ 
+    """Merges ``*.fastq`` files in ``input_dir`` into one FASTA file ``out_fa``.
+
+    ``input_dir`` is searched recursively so FASTQ files in nested folders are
+    also included.
+    """
     input_dir = Path(input_dir)
     out_fa = Path(out_fa)
     records: Iterable = []
-    for fq in sorted(input_dir.glob("*.fastq")):
+    for fq in sorted(input_dir.rglob("*.fastq")):
         records = list(records) + list(SeqIO.parse(fq, "fastq"))
     out_fa.parent.mkdir(parents=True, exist_ok=True)
     SeqIO.write(records, out_fa, "fasta") 

--- a/tests/test_trimming_recursion.py
+++ b/tests/test_trimming_recursion.py
@@ -1,0 +1,33 @@
+import pathlib
+import shutil
+from Bio import SeqIO
+from microseq_tests.trimming.ab1_to_fastq import ab1_folder_to_fastq
+from microseq_tests.trimming.fastq_to_fasta import fastq_folder_to_fasta
+
+
+def test_ab1_to_fastq_recursive(tmp_path: pathlib.Path) -> None:
+    fixtures = pathlib.Path(__file__).parent / "fixtures" / "39764260.ab1"
+    inp = tmp_path / "input"
+    nested = inp / "sub"
+    nested.mkdir(parents=True)
+    shutil.copy2(fixtures, inp / "top.ab1")
+    shutil.copy2(fixtures, nested / "inner.ab1")
+
+    out_dir = tmp_path / "fastq"
+    fastqs = ab1_folder_to_fastq(inp, out_dir)
+    assert len(fastqs) == 2
+    for fq in fastqs:
+        assert fq.exists()
+
+
+def test_fastq_to_fasta_recursive(tmp_path: pathlib.Path) -> None:
+    inp = tmp_path / "fq"
+    sub = inp / "deep"
+    sub.mkdir(parents=True)
+    (inp / "r1.fastq").write_text("@a\nACGT\n+\n!!!!\n")
+    (sub / "r2.fastq").write_text("@b\nTGCA\n+\n!!!!\n")
+
+    out = tmp_path / "out.fasta"
+    fastq_folder_to_fasta(inp, out)
+    records = list(SeqIO.parse(out, "fasta"))
+    assert len(records) == 2


### PR DESCRIPTION
## Summary
- recurse into subdirectories when converting AB1 and FASTQ files
- describe recursion in CLI help and README
- add tests for recursive searches

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*