### PR TITLE
Fix CLI aligner parsing and FASTQ handling

### DIFF
--- a/src/microseq_tests/aligners/_parse.py
+++ b/src/microseq_tests/aligners/_parse.py
@@ -7,11 +7,17 @@ from pathlib import Path
 COLS ="qseqid sseqid pident qlen qcovhsp length evalue bitscore stitle".split()
 
 def parse_blast_tab(tsv: Path) -> pd.DataFrame:
-    df = pd.read_csv(tsv, sep="\t", names = COLS, comment="#")
-    if df.iloc[0, 0] == "qseqid": # header present then remove it 
+    """Read BLAST/VSEARCH tabular output with typed columns."""
+    df = pd.read_csv(tsv, sep="\t", names=COLS, comment="#", dtype=str)
+
+    if not df.empty and df.iloc[0, 0] == "qseqid":
         df = df.iloc[1:]
 
-    return df[COLS].reset_index(drop=True) 
+    num_cols = ["pident", "qlen", "qcovhsp", "length", "evalue", "bitscore"]
+    for col in num_cols:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    return df[COLS].reset_index(drop=True)
  
 
 

--- a/src/microseq_tests/aligners/vsearch.py
+++ b/src/microseq_tests/aligners/vsearch.py
@@ -17,7 +17,12 @@ class VsearchAligner(BaseAligner):
         db_fa = f"{os.environ['MICROSEQ_DB_HOME']}/{db_key}/greengenes2_db.fasta"
 
         subprocess.run([
-            "vsearch", "--usearch_global", query_fa, "--db", db_fa, "--blast6out", out_tsv, "--threads", str(threads),], check=True) 
+            "vsearch", "--usearch_global", query_fa,
+            "--db", db_fa,
+            "--blast6out", out_tsv,
+            "--id", "0.8",
+            "--threads", str(threads),
+        ], check=True)
 
         df = parse_blast_tab(out_tsv)
         if not df.empty:

--- a/src/microseq_tests/microseq.py
+++ b/src/microseq_tests/microseq.py
@@ -254,7 +254,10 @@ def main() -> None:
 
         # choose engine
         if args.aligner == "auto":
-            longest = max(len(r.seq) for r in SeqIO.parse(args.input, "fasta"))
+            try:
+                longest = max(len(r.seq) for r in SeqIO.parse(args.input, "fasta"))
+            except ValueError:
+                longest = max(len(r.seq) for r in SeqIO.parse(args.input, "fastq"))
             chosen  = "blastn" if longest >= 1200 else "blastn"  # megablast handled inside BlastAligner via fast=True
         else:
             chosen = args.aligner


### PR DESCRIPTION
## Summary
- ensure blast/vsearch TSV parsing converts numeric columns
- add mandatory `--id` flag to vsearch runner
- fall back to FASTQ when checking record lengths in `microseq` CLI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*