### PR TITLE
Fix GUI timer cleanup

### DIFF
--- a/src/microseq_tests/gui/main_window.py
+++ b/src/microseq_tests/gui/main_window.py
@@ -643,6 +643,9 @@ class MainWindow(QMainWindow):
             # schedule (don’t force) the very last batch
             QTimer.singleShot(0, self._flush_log_batch)
 
+        if hasattr(self, "_flush_timer") and self._flush_timer.isActive():
+            self._flush_timer.stop()
+
         if getattr(self, "_thread", None):
             self._thread = None
 
@@ -728,6 +731,9 @@ class MainWindow(QMainWindow):
         if getattr(self, "_log_handler", None) in root.handlers:
             root.removeHandler(self._log_handler)
             self._log_handler = None
+
+        if hasattr(self, "_flush_timer") and self._flush_timer.isActive():
+            self._flush_timer.stop()
 
 # Application entry point ------------------
 def launch():


### PR DESCRIPTION
## Summary
- stop the log flush timer when cleaning up
- stop the timer when closing the GUI window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f76229548328a1cd6a4a1c2f0160